### PR TITLE
Replace React.render w/ ReactDOM.render

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ var App = React.createClass({
   }
 });
 
-React.render(<App/>, document.getElementById("content"));
+ReactDOM.render(<App/>, document.getElementById("content"));
 
 ```
 


### PR DESCRIPTION
React.render is deprecated since React v0.14. ReactDOM.render is intended to be used instead.
